### PR TITLE
separate binder_find logging

### DIFF
--- a/CriFs.V2.Hook/Config.cs
+++ b/CriFs.V2.Hook/Config.cs
@@ -21,7 +21,7 @@ public class Config : Configurable<Config>
     [DefaultValue(false)]
     public bool PrintFileRedirects { get; set; } = false;
     
-    [DisplayName("Print Binder Find")]
+    [DisplayName("Print Binder Access")]
     [Description("Prints all instances of Binder Find using the Info log level.")]
     [DefaultValue(false)]
     public bool PrintFileBinder { get; set; } = false;

--- a/CriFs.V2.Hook/Config.cs
+++ b/CriFs.V2.Hook/Config.cs
@@ -11,8 +11,8 @@ public class Config : Configurable<Config>
     [DefaultValue(true)]
     public bool DisableCriBindLogging { get; set; } = true;
     
-    [DisplayName("Print File Access")]
-    [Description("Prints loaded file to console using the Info log level.")]
+    [DisplayName("Print File Registration")]
+    [Description("Prints when a file is registered onto the internal CRI File Loader\nThis can be useful to find out when a file is being accessed for the first time.")]
     [DefaultValue(false)]
     public bool PrintFileAccess { get; set; } = false;
     
@@ -22,7 +22,7 @@ public class Config : Configurable<Config>
     public bool PrintFileRedirects { get; set; } = false;
     
     [DisplayName("Print Binder Access")]
-    [Description("Prints all instances of Binder Find using the Info log level.")]
+    [Description("Prints all instances of the Binder's Find function using the Info log level.\nThis can be used to detect file access initiated from internal CRI logic.")]
     [DefaultValue(false)]
     public bool PrintFileBinder { get; set; } = false;
     

--- a/CriFs.V2.Hook/Config.cs
+++ b/CriFs.V2.Hook/Config.cs
@@ -21,6 +21,11 @@ public class Config : Configurable<Config>
     [DefaultValue(false)]
     public bool PrintFileRedirects { get; set; } = false;
     
+    [DisplayName("Print Binder Find")]
+    [Description("Prints all instances of Binder Find using the Info log level.")]
+    [DefaultValue(false)]
+    public bool PrintFileBinder { get; set; } = false;
+    
     [DisplayName("Hot Reload")]
     [Description("Allows for loaded files to be updated/replaced at runtime.")]
     [DefaultValue(false)]

--- a/CriFs.V2.Hook/Config.cs
+++ b/CriFs.V2.Hook/Config.cs
@@ -14,7 +14,7 @@ public class Config : Configurable<Config>
     [DisplayName("Print File Registration")]
     [Description("Prints when a file is registered onto the internal CRI File Loader\nThis can be useful to find out when a file is being accessed for the first time.")]
     [DefaultValue(false)]
-    public bool PrintFileAccess { get; set; } = false;
+    public bool PrintFileRegister { get; set; } = false;
     
     [DisplayName("Print File Redirects")]
     [Description("Prints redirected files to console using the Info log level.")]
@@ -24,7 +24,7 @@ public class Config : Configurable<Config>
     [DisplayName("Print Binder Access")]
     [Description("Prints all instances of the Binder's Find function using the Info log level.\nThis can be used to detect file access initiated from internal CRI logic.")]
     [DefaultValue(false)]
-    public bool PrintFileBinder { get; set; } = false;
+    public bool PrintBinderAccess { get; set; } = false;
     
     [DisplayName("Hot Reload")]
     [Description("Allows for loaded files to be updated/replaced at runtime.")]

--- a/CriFs.V2.Hook/Hooks/CpkBinder.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder.cs
@@ -321,7 +321,7 @@ public static unsafe partial class CpkBinder
 
 
     /// <summary>
-    ///     Enables/disables printing of file access.
+    ///     Enables/disables printing of files being registered.
     /// </summary>
     public static void SetPrintFileRegister(bool printFileRegister)
     {
@@ -337,7 +337,7 @@ public static unsafe partial class CpkBinder
     }
 
     /// <summary>
-    ///     Enables/disables printing of file redirects.
+    ///     Enables/disables printing of Binder Accesses.
     /// </summary>
     public static void SetPrintBinderAccess(bool PrintBinderAccess)
     {

--- a/CriFs.V2.Hook/Hooks/CpkBinder.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder.cs
@@ -48,8 +48,8 @@ public static unsafe partial class CpkBinder
     private static int _additionalFiles;
     private static MemoryAllocation _libraryMemory;
     private static MemoryAllocatorWithLinkedListBackup _allocator;
-    private static bool _printFileAccess;
-    private static bool _printBinderFind;
+    private static bool _printFileRegister;
+    private static bool _printBinderAccess;
     private static bool _printFileRedirects;
 
     /// <remarks>
@@ -323,9 +323,9 @@ public static unsafe partial class CpkBinder
     /// <summary>
     ///     Enables/disables printing of file access.
     /// </summary>
-    public static void SetPrintFileAccess(bool printFileAccess)
+    public static void SetPrintFileRegister(bool printFileRegister)
     {
-        _printFileAccess = printFileAccess;
+        _printFileRegister = printFileRegister;
     }
 
     /// <summary>
@@ -339,9 +339,9 @@ public static unsafe partial class CpkBinder
     /// <summary>
     ///     Enables/disables printing of file redirects.
     /// </summary>
-    public static void SetPrintBinderFind(bool printBinderFind)
+    public static void SetPrintBinderAccess(bool PrintBinderAccess)
     {
-        _printBinderFind = printBinderFind;
+        _printBinderAccess = PrintBinderAccess;
     }
 
     /// <summary>

--- a/CriFs.V2.Hook/Hooks/CpkBinder.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder.cs
@@ -49,6 +49,7 @@ public static unsafe partial class CpkBinder
     private static MemoryAllocation _libraryMemory;
     private static MemoryAllocatorWithLinkedListBackup _allocator;
     private static bool _printFileAccess;
+    private static bool _printBinderFind;
     private static bool _printFileRedirects;
 
     /// <remarks>
@@ -333,6 +334,14 @@ public static unsafe partial class CpkBinder
     public static void SetPrintFileRedirect(bool printFileRedirects)
     {
         _printFileRedirects = printFileRedirects;
+    }
+
+    /// <summary>
+    ///     Enables/disables printing of file redirects.
+    /// </summary>
+    public static void SetPrintBinderFind(bool printBinderFind)
+    {
+        _printBinderFind = printBinderFind;
     }
 
     /// <summary>

--- a/CriFs.V2.Hook/Hooks/CpkBinder_CaseInsensitiveFileRedirections.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder_CaseInsensitiveFileRedirections.cs
@@ -215,7 +215,7 @@ public static unsafe partial class CpkBinder
             return _findFileHook!.OriginalFunction(bndrhn, path, finfo, exist); 
  
         var str = Marshal.PtrToStringAnsi(path); 
-        if (_printFileAccess) 
+        if (_printBinderFind) 
             _logger.Info("Binder_Find: {0}", str); 
  
         if (!_content.TryGetValue(SanitizeCriPath(str!), out _, out var originalKey)) 

--- a/CriFs.V2.Hook/Hooks/CpkBinder_CaseInsensitiveFileRedirections.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder_CaseInsensitiveFileRedirections.cs
@@ -189,7 +189,7 @@ public static unsafe partial class CpkBinder
             return _registerFileHook!.OriginalFunction(loader, binder, path, fileId, zero);
 
         var str = Marshal.PtrToStringAnsi(path);
-        if (_printFileAccess)
+        if (_printFileRegister)
             _logger.Info("Register_File: {0}", str);
 
         if (!_content.TryGetValue(SanitizeCriPath(str!), out _, out var originalKey))
@@ -215,7 +215,7 @@ public static unsafe partial class CpkBinder
             return _findFileHook!.OriginalFunction(bndrhn, path, finfo, exist); 
  
         var str = Marshal.PtrToStringAnsi(path); 
-        if (_printBinderFind) 
+        if (_printBinderAccess) 
             _logger.Info("Binder_Find: {0}", str); 
  
         if (!_content.TryGetValue(SanitizeCriPath(str!), out _, out var originalKey)) 

--- a/CriFs.V2.Hook/Mod.cs
+++ b/CriFs.V2.Hook/Mod.cs
@@ -145,6 +145,7 @@ public class Mod : ModBase, IExports // <= Do not Remove.
         CpkBinder.SetDisableLogging(_configuration.DisableCriBindLogging);
         CpkBinder.SetPrintFileAccess(_configuration.PrintFileAccess);
         CpkBinder.SetPrintFileRedirect(_configuration.PrintFileRedirects);
+        CpkBinder.SetPrintBinderFind(_configuration.PrintFileBinder);
         _cpkBuilder?.Build(); 
     }
 

--- a/CriFs.V2.Hook/Mod.cs
+++ b/CriFs.V2.Hook/Mod.cs
@@ -143,9 +143,9 @@ public class Mod : ModBase, IExports // <= Do not Remove.
         AssertAwbIncompatibility();
         CpkBinder.Init(_logger, _hooks!, _scannerFactory);
         CpkBinder.SetDisableLogging(_configuration.DisableCriBindLogging);
-        CpkBinder.SetPrintFileAccess(_configuration.PrintFileAccess);
+        CpkBinder.SetPrintFileRegister(_configuration.PrintFileRegister);
         CpkBinder.SetPrintFileRedirect(_configuration.PrintFileRedirects);
-        CpkBinder.SetPrintBinderFind(_configuration.PrintFileBinder);
+        CpkBinder.SetPrintBinderAccess(_configuration.PrintBinderAccess);
         _cpkBuilder?.Build(); 
     }
 
@@ -180,7 +180,7 @@ public class Mod : ModBase, IExports // <= Do not Remove.
         _logger.LogLevel = _configuration.LogLevel;
         _logger.Info($"[{_modConfig.ModId}] Config Updated: Applying");
         CpkBinder.SetDisableLogging(_configuration.DisableCriBindLogging);
-        CpkBinder.SetPrintFileAccess(_configuration.PrintFileAccess);
+        CpkBinder.SetPrintFileRegister(_configuration.PrintFileRegister);
         CpkBinder.SetPrintFileRedirect(_configuration.PrintFileRedirects);
         _cpkBuilder?.SetHotReload(_configuration.HotReload);
     }


### PR DESCRIPTION
Separated binder_find logging into its own toggle in the interested of having less pollution in file access logging.