### PR TITLE
Fix crash when disable bind warnings is disabled

### DIFF
--- a/CriFs.V2.Hook/Hooks/CpkBinder_DisableCriLogging.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder_DisableCriLogging.cs
@@ -10,9 +10,11 @@ namespace CriFs.V2.Hook.Hooks;
 /// </summary>
 public static unsafe partial class CpkBinder
 {
+    private static bool _previousCallCode1Set;
     private static readonly byte[] _previousCallCode1 = new byte[5];
     private static readonly byte[] _newCallCode1 = { 0x90, 0x90, 0x90, 0x90, 0x90 };
 
+    private static bool _previousCallCode2Set;
     private static readonly byte[] _previousCallCode2 = new byte[5];
     private static readonly byte[] _newCallCode2 = { 0x90, 0x90, 0x90, 0x90, 0x90 };
 
@@ -36,10 +38,11 @@ public static unsafe partial class CpkBinder
         var disableWarn = (byte*)Pointers.DisableFileBindWarning;
         if (disableLogging)
         {
+            _previousCallCode1Set = true;
             Memory.Instance.SafeRead((nuint)disableWarn, _previousCallCode1.AsSpan());
             Memory.Instance.SafeWrite((nuint)disableWarn, _newCallCode1.AsSpan());
         }
-        else
+        else if(_previousCallCode1Set)
         {
             Memory.Instance.SafeWrite((nuint)disableWarn, _previousCallCode1.AsSpan());
         }
@@ -54,10 +57,11 @@ public static unsafe partial class CpkBinder
         var disableWarn = (byte*)Pointers.DisableGetContentsInfoDetailsWarning;
         if (disableLogging)
         {
+            _previousCallCode2Set = true;
             Memory.Instance.SafeRead((nuint)disableWarn, _previousCallCode2.AsSpan());
             Memory.Instance.SafeWrite((nuint)disableWarn, _newCallCode2.AsSpan());
         }
-        else
+        else if(_previousCallCode2Set)
         {
             Memory.Instance.SafeWrite((nuint)disableWarn, _previousCallCode2.AsSpan());
         }

--- a/CriFs.V2.Hook/Hooks/CpkBinder_DisableCriLogging.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder_DisableCriLogging.cs
@@ -61,7 +61,7 @@ public static unsafe partial class CpkBinder
             Memory.Instance.SafeRead((nuint)disableWarn, _previousCallCode2.AsSpan());
             Memory.Instance.SafeWrite((nuint)disableWarn, _newCallCode2.AsSpan());
         }
-        else if(_previousCallCode2Set)
+        else if (_previousCallCode2Set)
         {
             Memory.Instance.SafeWrite((nuint)disableWarn, _previousCallCode2.AsSpan());
         }


### PR DESCRIPTION
When the "Disable bind warnings" configuration option is disabled on startup, a bunch of 00s are written over the logging functions instead of the original instructions (since they haven't been read yet). Simple fix, if those original instructions haven't been read yet then "enabling" bind warnings just does nothing, since they aren't disabled yet.

I must literally be the only person to ever disable this option since, if those warnings are triggered they're going to cause a crash. This really confused me for a while 🫠