### PR TITLE
add "GetProbingPaths" function to API

### DIFF
--- a/CriFs.V2.Hook/Api.cs
+++ b/CriFs.V2.Hook/Api.cs
@@ -34,6 +34,9 @@ public class Api : ICriFsRedirectorApi
     public void AddProbingPath(string relativePath) => _reloadedBuilder.AddProbingPath(relativePath);
 
     /// <inheritdoc/>
+    public List<string> GetProbingPaths() => _reloadedBuilder.GetProbingPaths();
+
+    /// <inheritdoc/>
     public void AddUnbindCallback(Action<ICriFsRedirectorApi.UnbindContext> callback) => _reloadedBuilder.AddUnbindCallback(callback);
 
     /// <inheritdoc/>

--- a/CriFs.V2.Hook/Api.cs
+++ b/CriFs.V2.Hook/Api.cs
@@ -34,7 +34,7 @@ public class Api : ICriFsRedirectorApi
     public void AddProbingPath(string relativePath) => _reloadedBuilder.AddProbingPath(relativePath);
 
     /// <inheritdoc/>
-    public List<string> GetProbingPaths() => _reloadedBuilder.GetProbingPaths();
+    public IReadOnlyList<string> GetProbingPaths() => _reloadedBuilder.GetProbingPaths();
 
     /// <inheritdoc/>
     public void AddUnbindCallback(Action<ICriFsRedirectorApi.UnbindContext> callback) => _reloadedBuilder.AddUnbindCallback(callback);

--- a/CriFs.V2.Hook/ModConfig.json
+++ b/CriFs.V2.Hook/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "crifs.v2.hook",
   "ModName": "CRI FileSystem V2 Hook",
   "ModAuthor": "Sewer56",
-  "ModVersion": "2.5.6",
+  "ModVersion": "2.6.0",
   "ModDescription": "A mod that allows you to add/replace existing files without repacking CRI Middleware CPKs.",
   "ModDll": "CriFs.V2.Hook.dll",
   "ModIcon": "Preview.png",

--- a/CriFs.V2.Hook/ModConfig.json
+++ b/CriFs.V2.Hook/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "crifs.v2.hook",
   "ModName": "CRI FileSystem V2 Hook",
   "ModAuthor": "Sewer56",
-  "ModVersion": "2.5.5",
+  "ModVersion": "2.5.6",
   "ModDescription": "A mod that allows you to add/replace existing files without repacking CRI Middleware CPKs.",
   "ModDll": "CriFs.V2.Hook.dll",
   "ModIcon": "Preview.png",

--- a/CriFs.V2.Hook/ReloadedBindBuilderCreator.cs
+++ b/CriFs.V2.Hook/ReloadedBindBuilderCreator.cs
@@ -64,6 +64,11 @@ public class ReloadedBindBuilderCreator
     public void AddProbingPath(string relativePath) => _probingPaths.Add(relativePath);
 
     /// <summary>
+    /// Returns all currently registered probing paths.
+    /// </summary>
+    public List<string> GetProbingPaths() => _probingPaths;
+
+    /// <summary>
     /// Tries to remove a mod from the internal list of mods to build.
     /// </summary>
     /// <param name="modConfig">The mod config to remove.</param>

--- a/CriFs.V2.Hook/ReloadedBindBuilderCreator.cs
+++ b/CriFs.V2.Hook/ReloadedBindBuilderCreator.cs
@@ -66,7 +66,7 @@ public class ReloadedBindBuilderCreator
     /// <summary>
     /// Returns all currently registered probing paths.
     /// </summary>
-    public List<string> GetProbingPaths() => _probingPaths;
+    public IReadOnlyList<string> GetProbingPaths() => _probingPaths;
 
     /// <summary>
     /// Tries to remove a mod from the internal list of mods to build.

--- a/Interfaces/CriFs.V2.Hook.Interfaces/ICriFsRedirectorApi.cs
+++ b/Interfaces/CriFs.V2.Hook.Interfaces/ICriFsRedirectorApi.cs
@@ -16,7 +16,7 @@ public interface ICriFsRedirectorApi
     /// <summary>
     /// Returns all currently registered probing paths.
     /// </summary>
-    public List<string> GetProbingPaths();
+    public IReadOnlyList<string> GetProbingPaths();
 
     /// <summary>
     /// Adds a method that is fired when the binder performs an unbind (e.g. Hot Reload).

--- a/Interfaces/CriFs.V2.Hook.Interfaces/ICriFsRedirectorApi.cs
+++ b/Interfaces/CriFs.V2.Hook.Interfaces/ICriFsRedirectorApi.cs
@@ -14,6 +14,11 @@ public interface ICriFsRedirectorApi
     public void AddProbingPath(string relativePath);
 
     /// <summary>
+    /// Returns all currently registered probing paths.
+    /// </summary>
+    public List<string> GetProbingPaths();
+
+    /// <summary>
     /// Adds a method that is fired when the binder performs an unbind (e.g. Hot Reload).
     /// </summary>
     /// <param name="callback">The callback method to fire.</param>


### PR DESCRIPTION
This adds a GetProbingPaths function to the API that returns a read only list of all probing paths currently added to the list.