### PR TITLE
Fix x64 BindFile patch truncating file count to 255 instead of -1

### DIFF
--- a/CriFs.V2.Hook/Hooks/CpkBinder_PatchBindFile.cs
+++ b/CriFs.V2.Hook/Hooks/CpkBinder_PatchBindFile.cs
@@ -86,7 +86,7 @@ public static unsafe partial class CpkBinder
                 {
                     var operandOffset = movRegSig.Length == 14 ? 1 : 2; // check if 32-bit register or not.
                     Memory.Instance.SafeWrite((nuint)((byte*)bindFile + res.Offset + operandOffset),
-                        new Span<byte>(&newValue, 1));
+                        new Span<byte>(&newValue, 4));
                     _logger.Info(message);
                 }
             }


### PR DESCRIPTION
## Preamble

So, long story short. I'm trying to create a custom localization for Persona 5 Royal. That basically means patching almost every .bf/.bmd file. Well, a better solution would be packing them into a .cpk, but here I am.
While doing so, I stumbled upon an issue, that with an increased number of translated files, some text becomes "untranslated" again. In the logs, I noticed that there were only 255 mentions of this block:
```
Register_File: %file%.BF
Register_File_Original: %file%.BF, BndrHn: 0
Register_File_Redirect: %file%.BF, BndrHn: 0
Open_Ansi_Redirect: %file%.BF
```
I mean, the 255 looks _really_ suspicious in this context.
Unfortunately, **the fix and the rest of the description were written by an LLM**, as I didn't want to spend much time trying to understand how this library works. And while I tested it and it solved my issue (all files from my localization mod are now loaded properly), I can't guarantee it won't create any new issues.

## Summary

On x64, the `BindFile` → "bind all files" patch writes only **1 byte** of a 4-byte
`mov r32, imm32` immediate. This turns `mov reg, 1` into `mov reg, 0x000000FF` (= **255**)
rather than the intended `mov reg, -1`, silently capping the number of bound files at 255.

Any mod that injects more than 255 files through a game lacking a native
`criFsBinder_BindFiles` is affected: files past the 255th are never bound, and because
the cutoff shifts as files are added, previously-working files break when new ones are added.

## Root cause

`CriFs.V2.Hook/Hooks/CpkBinder_PatchBindFile.cs`, in `TryPatchMovReg`:

```csharp
var newValue = -1;
...
Memory.Instance.SafeWrite((nuint)((byte*)bindFile + res.Offset + operandOffset),
    new Span<byte>(&newValue, 1));   // writes 1 of 4 immediate bytes
```
The instruction being patched (mov ecx,1 = b9 01 00 00 00, etc.) has a full 32-bit
immediate. Writing a single byte changes only the low byte:

```
b9 01 00 00 00   ->   b9 FF 00 00 00   ==   mov ecx, 0x000000FF  (255)
```
The comments in the same method already document the intended result as
`b9 ff ff ff ff` (all four bytes FF), confirming this is a truncation bug.

Only the x64 path is affected. The x86 paths are correct: `push -1` is `6A FF`
(a genuine 1-byte sign-extended immediate), and the inc→dec patch is a 1-byte
opcode swap.

## Fix
Write all 4 bytes of the immediate so the value is a true -1 (0xFFFFFFFF):

```csharp
Memory.Instance.SafeWrite((nuint)((byte*)bindFile + res.Offset + operandOffset),
    new Span<byte>(&newValue, 4));
```

## Impact
Affects every game profile that has no criFsBinder_BindFiles signature and therefore
relies on the patched single-file BindFile. On x64, these were all silently limited to 255 bound files.

## Testing
Reproduced on Persona 5 Royal (CRI File System/PCx64 Ver.2.81.6), whose CRI build
exposes criFsBinder_BindFile but not criFsBinder_BindFiles.

> One more guess from myself - I'm running P5R from the MS Store, and not the Steam version, so, if the criFsBinder_BindFiles is available for you - maybe that's why?